### PR TITLE
Update CMakeLists.txt to use target_include_directories for header file locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #----------------------------------------------------------------------
 #----------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(ni-grpc-sideband C CXX)
 
@@ -49,6 +49,11 @@ add_library(ni_grpc_sideband ${LIB_TYPE}
   src/sideband_shared_memory.cc
   src/sideband_rdma.cc
   )
+target_include_directories(ni_grpc_sideband
+  PUBLIC
+	  src
+    moniker_src)
+
 if (INCLUDE_SIDEBAND_RDMA)
   target_link_libraries(ni_grpc_sideband
     ${_REFLECTION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(ni_grpc_sideband ${LIB_TYPE}
   )
 target_include_directories(ni_grpc_sideband
   PUBLIC
-	  src
+    src
     moniker_src)
 
 if (INCLUDE_SIDEBAND_RDMA)


### PR DESCRIPTION
Max had a comment that if the sideband could specify its header file's locations so that components that depend on the library wouldn't need to add these themselves in the grpc-device repo. Hence,
- I've updated the code to include target directories.
- I've updated the minimum cmake version as include target directories is supported from 3.11.0 version.