### PR TITLE
Use port passed when initializing to get the address information

### DIFF
--- a/src/sideband_data.cc
+++ b/src/sideband_data.cc
@@ -332,12 +332,11 @@ std::string GetConnectionAddress(::SidebandStrategy strategy)
         {
             address = GetRdmaAddress() + ":50060";
         }
-        else
         {
-            address = GetSocketsAddress() + ":50055";
+            address = GetSocketsAddress() + ":" + GetSocketsPort();
         }
     #else
-        address = GetSocketsAddress() + ":50055";
+        address = GetSocketsAddress() + ":" + GetSocketsPort();
     #endif
     std::cout << "Connection address: " << address << std::endl;
     return address;

--- a/src/sideband_internal.h
+++ b/src/sideband_internal.h
@@ -210,3 +210,4 @@ std::string GetRdmaAddress();
 #endif
 
 std::string GetSocketsAddress();
+std::string GetSocketsPort();

--- a/src/sideband_sockets.cc
+++ b/src/sideband_sockets.cc
@@ -35,6 +35,7 @@
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 static std::string s_SidebandSocketsAddress;
+static int s_SidebandSocketsPort;
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
@@ -340,6 +341,17 @@ std::string GetSocketsAddress()
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
+std::string GetSocketsPort()
+{
+    if (s_SidebandSocketsPort > 0)
+    {
+        return std::to_string(s_SidebandSocketsPort);
+    }
+    return "50055";
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 int32_t _SIDEBAND_FUNC RunSidebandSocketsAccept(const char* address, int port)
 {
     int sockfd, newsockfd;
@@ -352,6 +364,7 @@ int32_t _SIDEBAND_FUNC RunSidebandSocketsAccept(const char* address, int port)
 #endif
 
     s_SidebandSocketsAddress = address;
+    s_SidebandSocketsPort = port;
 
     // create a socket
     sockfd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);


### PR DESCRIPTION
We did not utilize the port passed when calling **RunSidebandSocketsAccept** and **GetConnectionAddress** always returned the hard-coded **50055** port.

To address this, we need to store the port in a member, similar to how the address is stored. Additionally, updated the **GetConnectionAddress** implementation to retrieve the port from the newly created helper method.