### PR TITLE
Close sideband socket if there's a trigger

### DIFF
--- a/src/sideband_data.h
+++ b/src/sideband_data.h
@@ -1,6 +1,7 @@
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 #pragma once
+#include <atomic>
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
@@ -51,7 +52,7 @@ int32_t _SIDEBAND_FUNC CloseSidebandData(int64_t dataToken);
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
-int32_t _SIDEBAND_FUNC RunSidebandSocketsAccept(const char* address, int port);
+int32_t _SIDEBAND_FUNC RunSidebandSocketsAccept(const char* address, int port, std::atomic<bool>& stop_flag);
 int32_t _SIDEBAND_FUNC AcceptSidebandRdmaSendRequests();
 int32_t _SIDEBAND_FUNC AcceptSidebandRdmaReceiveRequests();
 int32_t _SIDEBAND_FUNC GetSidebandConnectionAddress(::SidebandStrategy strategy, char address[1024]);


### PR DESCRIPTION
We now have an extra parameter that tells whether to close the sideband socket or not.

As accept, is a blocking call, we can't just check the variable for the trigger, as it will remain blocked until a connection is established.
Hence, I've updated it to use select. The select function monitors multiple file descriptors to see if any of them are ready.
It returns the number of file descriptors that are ready for the requested I/O, or -1 if an error occurs. 
If it's greater than 0, it means that one or more file descriptors are ready for reading. The code then checks if the sockfd file descriptor is ready using the FD_ISSET macro. If sockfd is ready, it indicates that there is an incoming connection and we do the remaining operation accordingly.

Tested it, when the boolean is set to true, the loop breaks and the socket closes.